### PR TITLE
Fix IllegalArgumentException in getMixers()

### DIFF
--- a/src/main/kotlin/com/pattexpattex/kvintakord/music/audio/AudioDispatcher.kt
+++ b/src/main/kotlin/com/pattexpattex/kvintakord/music/audio/AudioDispatcher.kt
@@ -86,7 +86,13 @@ class AudioDispatcher(
         val lineInfo = Line.Info(SourceDataLine::class.java)
 
         return AudioSystem.getMixerInfo()
-            .map(AudioSystem::getMixer)
+            .mapNotNull {
+                try {
+                    AudioSystem.getMixer(it)
+                } catch (ignored: IllegalArgumentException) {
+                    null
+                }
+            }
             .filter { it.isLineSupported(lineInfo) }
     }
 


### PR DESCRIPTION
This PR fixes a bug where `AudioSystem#getMixer(Mixer.Info)` would throw an `IllegalArgumentException`.
The exception would interrupt the `AudioStuckCheckerThread` during startup and disable automatic mixer change detection.

Stacktrace:
```
10:55:16.711 AudioStuckCheckerThread    tornadofx.DefaultErrorHandler        #uncaughtException        L32    ErrorHandler                   ERROR  Uncaught error
java.lang.IllegalArgumentException: Mixer not supported: /.../
	at java.desktop/javax.sound.sampled.AudioSystem.getMixer(AudioSystem.java:210)
	at com.pattexpattex.kvintakord.music.audio.AudioDispatcher.getMixers(AudioDispatcher.kt:89)
	at com.pattexpattex.kvintakord.music.audio.AudioDispatcher._init_$lambda$2(AudioDispatcher.kt:49)
	at java.base/java.lang.Thread.run(Thread.java:833)
```